### PR TITLE
Needs PHP >= 7.1 to run properly.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": ">=5.6.0"
+        "php": ">=7.1.0"
     },
 
     "autoload": {


### PR DESCRIPTION
The package uses class constant visibility, here:

https://github.com/haruncpi/wp-api/blob/fb87d145d40cf44e46310381d4ad410a0faa8e90/src/ApiRoute.php#L22-L23

Support for class constant visibility wasn't **[added to PHP until 7.1](https://www.php.net/manual/en/migration71.new-features.php#migration71.new-features.class-constant-visibility)**, so accordingly, the minimum PHP version required in order to run the package properly as indicated by `composer.json` should be increased from 5.6 to at least 7.1 (possibly further, but this is something I discovered after a brief glance at the package, and I haven't tested the entire package extensively to confirm whether other compatibility concerns might exist, so for the moment, until reason is found to indicate otherwise, 7.1 should be okay).